### PR TITLE
syntax, 1 extra close curly

### DIFF
--- a/plug.ex
+++ b/plug.ex
@@ -43,7 +43,7 @@ defmodule Absinthe.Plug do
     do_call(conn, input, variables, context, config)
   end
 
-  def do_call(conn, input, variables, context, %{schema: schema, adapter: adapter, json_codec: json_codec}}) do
+  def do_call(conn, input, variables, context, %{schema: schema, adapter: adapter, json_codec: json_codec}) do
     with {:ok, doc} <- Absinthe.parse(input),
       :ok <- validate_single_operation(doc),
       :ok <- validate_http_method(conn, doc),


### PR DESCRIPTION
fixes

```
== Compilation error on file lib/myapp/web/plug.ex ==
** (SyntaxError) lib/myapp/web/plug.ex:46: "(" is missing terminator ")". unexpected token: "}" at line 46
    (elixir) lib/kernel/parallel_compiler.ex:117: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
```